### PR TITLE
add json and quiet flags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,70 +1,76 @@
 #!/usr/bin/env node
 
-const helpers = require('./helpers')
+const helpers = require('./helpers')(() => {
+  if (helpers.argv.help) {
+    console.log(helpers.help)
+    return
+  }
+  helpers.setup()
 
-helpers.setup()
+  const { log } = helpers
 
-console.log('Calculating...')
-console.log()
+  log('Calculating...')
+  log()
 
-/*
-    Get size for all node modules
-    {
-        // name: size in bytes,
-        a: 40,
-        b: 220
-    }
-*/
-const moduleSizes = helpers.getSizeForNodeModules()
+  /*
+  Get size for all node modules
+  {
+    // name: size in bytes,
+    a: 40,
+    b: 220
+  }
+  */
+  const moduleSizes = helpers.getSizeForNodeModules()
 
-/*
-    Get root dependencies from tree
-    These are the ones declared as dependendies in package.json
-    [a, b, c, d]
-*/
-let rootDependencies = helpers.getRootDependencies()
+  /*
+  Get root dependencies from tree
+  These are the ones declared as dependendies in package.json
+  [a, b, c, d]
+  */
+  let rootDependencies = helpers.getRootDependencies()
 
-/*
-    Attach the nested dependendies in a flat manner
-    [{
-        name: rootDependency,
-        children: [a, b, c, d]
-    }]
-*/
-let flatDependencies = helpers.attachNestedDependencies(rootDependencies)
+  /*
+  Attach the nested dependendies in a flat manner
+  [{
+  name: rootDependency,
+  children: [a, b, c, d]
+  }]
+  */
+  let flatDependencies = helpers.attachNestedDependencies(rootDependencies)
 
-/*
-    Modules actual size = size of the module + size of it's children
-*/
-for (let i = 0; i < flatDependencies.length; i++) {
-  let dep = flatDependencies[i]
+  /*
+  Modules actual size = size of the module + size of it's children
+  */
+  for (let i = 0; i < flatDependencies.length; i++) {
+    let dep = flatDependencies[i]
 
-  let sizeOfModule = moduleSizes[dep.name]
+    let sizeOfModule = moduleSizes[dep.name]
 
-  let sizeOfChildren = 0
-  dep.children.forEach(child => {
-    sizeOfChildren += moduleSizes[child] || 0
+    let sizeOfChildren = 0
+    dep.children.forEach(child => {
+      sizeOfChildren += moduleSizes[child] || 0
+    })
+
+    dep.actualSize = sizeOfModule + sizeOfChildren
+    dep.numberOfChildren = dep.children.length
+  }
+
+  /*
+  All dependencies =
+  Root dependencies +  all their children
+  Deduplicated
+  */
+  let allDependencies = helpers.getAllDependencies(flatDependencies)
+
+  /* Total size of node_modules */
+  let totalSize = 0
+  allDependencies.forEach(dep => {
+    totalSize += moduleSizes[dep] || 0
   })
 
-  dep.actualSize = sizeOfModule + sizeOfChildren
-  dep.numberOfChildren = dep.children.length
-}
+  /* Display results */
+  helpers.displayResults(flatDependencies, allDependencies, totalSize)
 
-/*
-    All dependencies =
-    Root dependencies +  all their children
-    Deduplicated
-*/
-let allDependencies = helpers.getAllDependencies(flatDependencies)
-
-/* Total size of node_modules */
-let totalSize = 0
-allDependencies.forEach(dep => {
-  totalSize += moduleSizes[dep] || 0
-})
-
-/* Display results */
-helpers.displayResults(flatDependencies, allDependencies, totalSize)
-
-/* Return to original state */
-helpers.teardown()
+  /* Return to original state */
+  helpers.teardown()
+})()


### PR DESCRIPTION
Hey there,

I added `--json`, `--quiet` and `--help` flags. I think they're pretty straightforward to use:

```
cost-of-modules -q
```

Only logs the final output, no intermediate commentary

```
cost-of-modules -j
```

Logs the output as a json blob

```
cost-of-modules -j=2
```

passes the 2 to `JSON.stringify(x, null, 2)`

```
cost-of-modules --help
```

Prints help and does no additional work.

Please let me know if there are additional steps I need to take.

Thanks,

Brekk